### PR TITLE
Privacy sans elk

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To run these tutorials, you must have the following installed:
 
 - [Docker and Docker-compose](https://docs.docker.com/compose/install/)
 
-| ⚠️ **Note**: If on MacOS, please ensure that you allow docker to use upto 4G of memory under the _Resources_ section. The docker [site](https://docs.docker.com/docker-for-mac/) has details on how to do this |
+| ⚠️ **Note**: If on MacOS, please ensure that you allow docker to use upto 4G of memory or 6G if running Privacy examples under the _Resources_ section. The docker [site](https://docs.docker.com/docker-for-mac/) has details on how to do this |
 | --- |
 
 

--- a/docker-compose_elk_privacy.yml
+++ b/docker-compose_elk_privacy.yml
@@ -235,6 +235,68 @@ services:
     ports:
       - 3000:3000/tcp
 
+  redis:
+    image: redis:alpine
+
+  elasticsearch:
+    build: ./elasticsearch
+    environment:
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "http.host=0.0.0.0"
+      - "transport.host=127.0.0.1"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    cap_add:
+      - IPC_LOCK
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.4.2
+    environment:
+      ELASTICSEARCH_HOSTS: "http://elasticsearch:9200"
+      XPACK_MONITORING_ENABLED: "true"
+      XPACK_MONITORING_COLLECTION_ENABLED: "true"
+      SERVER_NAME: "localhost"
+    depends_on:
+      - elasticsearch
+    links:
+      - elasticsearch
+    ports:
+      - 5601:5601/tcp
+
+  logstash:
+    build: ./logstash
+    environment:
+      - ES_HOST=http://elasticsearch:9200
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+    depends_on:
+      - redis
+      - elasticsearch
+    links:
+      - redis
+      - elasticsearch
+
+  filebeat:
+    build: ./filebeat
+    environment:
+      - ENV_NAME=dev
+      - IP_ADDRESS=127.0.0.1
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+    depends_on:
+      - redis
+    links:
+      - redis
+    volumes:
+      - ./logs/besu/:/var/log/besu/
+      - ./logs/orion/:/var/log/orion/
+
 volumes:
   public-keys:
 

--- a/docker-compose_elk_privacy_poa.yml
+++ b/docker-compose_elk_privacy_poa.yml
@@ -41,24 +41,46 @@ services:
     environment:
       - BESU_PUBLIC_KEY_DIRECTORY=${BESU_PUBLIC_KEY_DIRECTORY}
       - LOG4J_CONFIGURATION_FILE=/config/log-config.xml
-    entrypoint: /opt/besu/bootnode_start.sh --network=dev --min-gas-price=0 --host-whitelist=* --metrics-enabled --metrics-host=0.0.0.0 --metrics-port=9545
+    entrypoint: /opt/besu/bootnode_start.sh
+    command: &base_options [
+      "--data-path=/opt/besu/data",
+      "--genesis-file=/config/genesis.json",
+      "--node-private-key-file=/opt/besu/keys/key",
+      "--rpc-http-enabled",
+      "--rpc-http-api=WEB3,ETH,NET,EEA,ADMIN,${QUICKSTART_POA_API-ibft}",
+      "--rpc-http-host=0.0.0.0",
+      "--rpc-http-port=8545",
+      "--rpc-http-cors-origins=*",
+      "--rpc-ws-enabled",
+      "--rpc-ws-api=WEB3,ETH,NET,EEA,ADMIN,${QUICKSTART_POA_API-ibft}",
+      "--rpc-ws-host=0.0.0.0",
+      "--rpc-ws-port=8546",
+      "--graphql-http-enabled",
+      "--graphql-http-host=0.0.0.0",
+      "--graphql-http-port=8547",
+      "--graphql-http-cors-origins=*",
+      "--metrics-enabled",
+      "--metrics-host=0.0.0.0",
+      "--metrics-port=9545",
+      "--host-whitelist=*"]
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/log-config.xml:/config/log-config.xml
+      - ./config/besu/${QUICKSTART_POA_NAME-ibft2}Genesis.json:/config/genesis.json
+      - ./config/besu/networkFiles/bootnode/keys:/opt/besu/keys
       - ./logs/besu:/var/log/
 
   rpcnode: #  We keep one node named rpcnode to have a specific node to connect the explorer
     image: quickstart/besu:${BESU_VERSION}-privacy
     environment:
       - BESU_PUBLIC_KEY_DIRECTORY=${BESU_PUBLIC_KEY_DIRECTORY}
-      - LOG4J_CONFIGURATION_FILE=/config/log-config.xml
     command: [
-      "--network=dev",
+      "--genesis-file=/config/genesis.json",
       "--rpc-http-enabled",
       "--rpc-http-host=0.0.0.0",
       "--rpc-http-port=8545",
       "--rpc-http-cors-origins=*",
-      "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV",
+      "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV,${QUICKSTART_POA_API-ibft}",
       "--rpc-ws-enabled",
       "--rpc-ws-host=0.0.0.0",
       "--rpc-ws-port=8546",
@@ -70,45 +92,26 @@ services:
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/log-config.xml:/config/log-config.xml
+      - ./config/besu/${QUICKSTART_POA_NAME-ibft2}Genesis.json:/config/genesis.json
+      - ./config/besu/networkFiles/rpcnode/keys:/opt/besu/keys
       - ./logs/besu:/var/log/
     depends_on:
       - bootnode
     ports:
       - 8545:8545/tcp
 
-  minernode:
-    image: quickstart/besu:${BESU_VERSION}-privacy
-    environment:
-      - BESU_PUBLIC_KEY_DIRECTORY=${BESU_PUBLIC_KEY_DIRECTORY}
-      - LOG4J_CONFIGURATION_FILE=/config/log-config.xml
-    command: [
-      "--network=dev",
-      "--miner-enabled",
-      "--miner-coinbase=${MINER_COINBASE}",
-      "--metrics-enabled",
-      "--metrics-host=0.0.0.0",
-      "--metrics-port=9545",
-      "--min-gas-price=0"]
-    volumes:
-      - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
-      - ./config/besu/log-config.xml:/config/log-config.xml
-      - ./logs/besu:/var/log/
-    depends_on:
-      - bootnode
-
   node1:
     image: quickstart/besu:${BESU_VERSION}-privacy
     environment:
       - BESU_PUBLIC_KEY_DIRECTORY=${BESU_PUBLIC_KEY_DIRECTORY}
-      - LOG4J_CONFIGURATION_FILE=/config/log-config.xml
     command: [
       "--node-private-key-file=/opt/besu/keys/key",
-      "--network=dev",
+      "--genesis-file=/config/genesis.json",
       "--rpc-http-enabled",
       "--rpc-http-host=0.0.0.0",
       "--rpc-http-port=8545",
       "--rpc-http-cors-origins=*",
-      "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV",
+      "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV,${QUICKSTART_POA_API-ibft}",
       "--rpc-ws-enabled",
       "--rpc-ws-host=0.0.0.0",
       "--rpc-ws-port=8546",
@@ -123,9 +126,10 @@ services:
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/log-config.xml:/config/log-config.xml
-      - ./config/orion/networkFiles/orion1/nodeKey.pub:/config/orion/orion.pub
-      - ./config/besu/networkFiles/node1/keys:/opt/besu/keys
+      - ./config/besu/${QUICKSTART_POA_NAME-ibft2}Genesis.json:/config/genesis.json
+      - ./config/besu/networkFiles/node3/keys:/opt/besu/keys
       - ./logs/besu:/var/log/
+      - ./config/orion/networkFiles/orion1/nodeKey.pub:/config/orion/orion.pub
     depends_on:
       - bootnode
       - orion1
@@ -137,15 +141,14 @@ services:
     image: quickstart/besu:${BESU_VERSION}-privacy
     environment:
       - BESU_PUBLIC_KEY_DIRECTORY=${BESU_PUBLIC_KEY_DIRECTORY}
-      - LOG4J_CONFIGURATION_FILE=/config/log-config.xml
     command: [
       "--node-private-key-file=/opt/besu/keys/key",
-      "--network=dev",
+      "--genesis-file=/config/genesis.json",
       "--rpc-http-enabled",
       "--rpc-http-host=0.0.0.0",
       "--rpc-http-port=8545",
       "--rpc-http-cors-origins=*",
-      "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV",
+      "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV,${QUICKSTART_POA_API-ibft}",
       "--rpc-ws-enabled",
       "--rpc-ws-host=0.0.0.0",
       "--rpc-ws-port=8546",
@@ -160,9 +163,10 @@ services:
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/log-config.xml:/config/log-config.xml
-      - ./config/orion/networkFiles/orion2/nodeKey.pub:/config/orion/orion.pub
-      - ./config/besu/networkFiles/node2/keys:/opt/besu/keys
+      - ./config/besu/${QUICKSTART_POA_NAME-ibft2}Genesis.json:/config/genesis.json
+      - ./config/besu/networkFiles/node4/keys:/opt/besu/keys
       - ./logs/besu:/var/log/
+      - ./config/orion/networkFiles/orion2/nodeKey.pub:/config/orion/orion.pub
     depends_on:
       - bootnode
       - orion2
@@ -174,15 +178,14 @@ services:
     image: quickstart/besu:${BESU_VERSION}-privacy
     environment:
       - BESU_PUBLIC_KEY_DIRECTORY=${BESU_PUBLIC_KEY_DIRECTORY}
-      - LOG4J_CONFIGURATION_FILE=/config/log-config.xml
     command: [
       "--node-private-key-file=/opt/besu/keys/key",
-      "--network=dev",
+      "--genesis-file=/config/genesis.json",
       "--rpc-http-enabled",
       "--rpc-http-host=0.0.0.0",
       "--rpc-http-port=8545",
       "--rpc-http-cors-origins=*",
-      "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV",
+      "--rpc-http-api=EEA,WEB3,ETH,NET,PRIV,${QUICKSTART_POA_API-ibft}",
       "--rpc-ws-enabled",
       "--rpc-ws-host=0.0.0.0",
       "--rpc-ws-port=8546",
@@ -197,9 +200,10 @@ services:
     volumes:
       - public-keys:${BESU_PUBLIC_KEY_DIRECTORY}
       - ./config/besu/log-config.xml:/config/log-config.xml
-      - ./config/orion/networkFiles/orion3/nodeKey.pub:/config/orion/orion.pub
-      - ./config/besu/networkFiles/node3/keys:/opt/besu/keys
+      - ./config/besu/${QUICKSTART_POA_NAME-ibft2}Genesis.json:/config/genesis.json
+      - ./config/besu/networkFiles/node5/keys:/opt/besu/keys
       - ./logs/besu:/var/log/
+      - ./config/orion/networkFiles/orion3/nodeKey.pub:/config/orion/orion.pub
     depends_on:
       - bootnode
       - orion3
@@ -209,7 +213,7 @@ services:
 
   explorer:
     build: block-explorer-light/.
-    image: "quickstart/block-explorer-light:${BESU_VERSION}"
+    image: quickstart/block-explorer-light:${BESU_VERSION}-${QUICKSTART_POA_NAME-ibft2}
     depends_on:
       - rpcnode
     ports:
@@ -234,6 +238,67 @@ services:
       - grafana:/var/lib/grafana
     ports:
       - 3000:3000/tcp
+
+  redis:
+    image: redis:alpine
+
+  elasticsearch:
+    build: ./elasticsearch
+    environment:
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "http.host=0.0.0.0"
+      - "transport.host=127.0.0.1"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    cap_add:
+      - IPC_LOCK
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.4.2
+    environment:
+      ELASTICSEARCH_HOSTS: "http://elasticsearch:9200"
+      XPACK_MONITORING_ENABLED: "true"
+      XPACK_MONITORING_COLLECTION_ENABLED: "true"
+      SERVER_NAME: "localhost"
+    depends_on:
+      - elasticsearch
+    links:
+      - elasticsearch
+    ports:
+      - 5601:5601/tcp
+
+  logstash:
+    build: ./logstash
+    environment:
+      - ES_HOST=http://elasticsearch:9200
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+    depends_on:
+      - redis
+      - elasticsearch
+    links:
+      - redis
+      - elasticsearch
+
+  filebeat:
+    build: ./filebeat
+    environment:
+      - ENV_NAME=dev
+      - IP_ADDRESS=127.0.0.1
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+    depends_on:
+      - redis
+    links:
+      - redis
+    volumes:
+      - ./logs/besu/:/var/log/besu/
 
 volumes:
   public-keys:

--- a/docker-compose_privacy_poa.yml
+++ b/docker-compose_privacy_poa.yml
@@ -1,7 +1,7 @@
 ---
   version: '3.4'
   services:
-  
+
     orion1:
       image: "pegasyseng/orion:develop"
       environment:
@@ -11,7 +11,7 @@
         - ./config/orion/log-config.xml:/config/log-config.xml
         - ./config/orion/networkFiles/orion1:/config/orion/
         - ./logs/orion:/var/log/
-  
+
     orion2:
       image: "pegasyseng/orion:develop"
       environment:
@@ -21,7 +21,7 @@
         - ./config/orion/log-config.xml:/config/log-config.xml
         - ./config/orion/networkFiles/orion2:/config/orion/
         - ./logs/orion:/var/log/
-  
+
     orion3:
       image: "pegasyseng/orion:develop"
       environment:
@@ -31,7 +31,7 @@
         - ./config/orion/log-config.xml:/config/log-config.xml
         - ./config/orion/networkFiles/orion3:/config/orion/
         - ./logs/orion:/var/log/
-  
+
     bootnode:
       build:
         context: besu/.
@@ -69,7 +69,7 @@
         - ./config/besu/${QUICKSTART_POA_NAME-ibft2}Genesis.json:/config/genesis.json
         - ./config/besu/networkFiles/bootnode/keys:/opt/besu/keys
         - ./logs/besu:/var/log/
-  
+
     rpcnode: #  We keep one node named rpcnode to have a specific node to connect the explorer
       image: quickstart/besu:${BESU_VERSION}-privacy
       environment:
@@ -99,7 +99,7 @@
         - bootnode
       ports:
         - 8545:8545/tcp
-    
+
     node1:
       image: quickstart/besu:${BESU_VERSION}-privacy
       environment:
@@ -136,7 +136,7 @@
       ports:
         - 20000:8545/tcp
         - 20001:8546/tcp
-  
+
     node2:
       image: quickstart/besu:${BESU_VERSION}-privacy
       environment:
@@ -173,7 +173,7 @@
       ports:
         - 20002:8545/tcp
         - 20003:8546/tcp
-  
+
     node3:
       image: quickstart/besu:${BESU_VERSION}-privacy
       environment:
@@ -210,7 +210,7 @@
       ports:
         - 20004:8545/tcp
         - 20005:8546/tcp
-  
+
     explorer:
       build: block-explorer-light/.
       image: quickstart/block-explorer-light:${BESU_VERSION}-${QUICKSTART_POA_NAME-ibft2}
@@ -218,7 +218,7 @@
         - rpcnode
       ports:
         - "${EXPLORER_PORT_MAPPING:-}80"
-  
+
     prometheus:
       image: "prom/prometheus"
       volumes:
@@ -228,7 +228,7 @@
         - --config.file=/etc/prometheus/prometheus.yml
       ports:
         - 9090:9090/tcp
-  
+
     grafana:
       image: "grafana/grafana"
       environment:
@@ -238,71 +238,10 @@
         - grafana:/var/lib/grafana
       ports:
         - 3000:3000/tcp
-  
-    redis:
-      image: redis:alpine
-  
-    elasticsearch:
-      build: ./elasticsearch
-      environment:
-        - bootstrap.memory_lock=true
-        - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
-        - "http.host=0.0.0.0"
-        - "transport.host=127.0.0.1"
-      ulimits:
-        memlock:
-          soft: -1
-          hard: -1
-        nofile:
-          soft: 65536
-          hard: 65536
-      cap_add:
-        - IPC_LOCK
-  
-    kibana:
-      image: docker.elastic.co/kibana/kibana:7.4.2
-      environment:
-        ELASTICSEARCH_HOSTS: "http://elasticsearch:9200"
-        XPACK_MONITORING_ENABLED: "true"
-        XPACK_MONITORING_COLLECTION_ENABLED: "true"
-        SERVER_NAME: "localhost"
-      depends_on:
-        - elasticsearch
-      links:
-        - elasticsearch
-      ports:
-        - 5601:5601/tcp
-  
-    logstash:
-      build: ./logstash
-      environment:
-        - ES_HOST=http://elasticsearch:9200
-        - REDIS_HOST=redis
-        - REDIS_PORT=6379
-      depends_on:
-        - redis
-        - elasticsearch
-      links:
-        - redis
-        - elasticsearch
-  
-    filebeat:
-      build: ./filebeat
-      environment:
-        - ENV_NAME=dev
-        - IP_ADDRESS=127.0.0.1
-        - REDIS_HOST=redis
-        - REDIS_PORT=6379
-      depends_on:
-        - redis
-      links:
-        - redis
-      volumes:
-        - ./logs/besu/:/var/log/besu/
-  
+
   volumes:
     public-keys:
-  
+
     prometheus:
-  
+
     grafana:

--- a/run-privacy.sh
+++ b/run-privacy.sh
@@ -17,7 +17,6 @@ NO_LOCK_REQUIRED=true
 . ./.common.sh
 
 
-composeFile="-f docker-compose_privacy.yml"
 PARAMS=""
 
 displayUsage()
@@ -30,6 +29,7 @@ displayUsage()
                                               automatically selected by Docker."
   echo "    -c or --consensus <ibft2|clique|ethash> : the consensus mechanism that you want to run
                                               on your network, default is ethash"
+  echo "    -e or --elk                             : setup ELK with the network."
   exit 0
 }
 
@@ -42,22 +42,24 @@ displayUsage()
 ibft2='ibft'
 clique='clique' # value to use for clique option
 
-while [ $# -gt 0 ]; do
-  case "$1" in
-    -h|--help)
+composeFile="docker-compose_privacy"
+
+while getopts "hep:c:" o; do
+  case "${o}" in
+    h)
       displayUsage
       ;;
-    -p|--explorer-port)
-      export EXPLORER_PORT_MAPPING="${2}:"
-      shift 2
+    p)
+      port=${OPTARG}
+      export EXPLORER_PORT_MAPPING="$port:"
       ;;
-    -c|--consensus)
-      case "${2}" in
+    c)
+      algo=${OPTARG}
+      case "${algo}" in
         ibft2|clique)
-          export QUICKSTART_POA_NAME="${2}"
-          export QUICKSTART_POA_API="${!2}"
-          export QUICKSTART_VERSION="${BESU_VERSION}-${QUICKSTART_POA_NAME}"
-          composeFile="-f docker-compose_privacy_poa.yml"
+          export QUICKSTART_POA_API="${!algo}"
+          export QUICKSTART_VERSION="${BESU_VERSION}-${algo}"
+          composeFile="${composeFile}_poa"
           ;;
         ethash)
           ;;
@@ -65,18 +67,18 @@ while [ $# -gt 0 ]; do
           echo "Error: Unsupported consensus value." >&2
           displayUsage
       esac
-      shift 2
       ;;
-    --) # end argument parsing
-      shift
-      break
+    e)
+      elk_compose="${composeFile/docker-compose/docker-compose_elk}"
+      composeFile="$elk_compose"
       ;;
-    -*|--*=) # unsupported flags
-      echo "Error: Unsupported flag." >&2
+    *)
       displayUsage
-      ;;
+    ;;
   esac
 done
+
+composeFile="-f ${composeFile}.yml"
 
 # Build and run containers and network
 echo "${composeFile}" > ${LOCK_FILE}

--- a/run-privacy.sh
+++ b/run-privacy.sh
@@ -24,12 +24,12 @@ displayUsage()
   echo "This script creates and start a local private Besu network using Docker."
   echo "You can select the consensus mechanism to use.\n"
   echo "Usage: ${me} [OPTIONS]"
-  echo "    -p or --explorer-port <NUMBER>          : the port number you want to use for the endpoint
-                                              mapping, otherwise default is a port
-                                              automatically selected by Docker."
-  echo "    -c or --consensus <ibft2|clique|ethash> : the consensus mechanism that you want to run
-                                              on your network, default is ethash"
-  echo "    -e or --elk                             : setup ELK with the network."
+  echo "    -p <NUMBER>              : the port number you want to use for the endpoint
+                                       mapping, otherwise default is a port
+                                       automatically selected by Docker."
+  echo "    -c <ibft2|clique|ethash> : the consensus mechanism that you want to run
+                                       on your network, default is ethash"
+  echo "    -e                       : setup ELK with the network."
   exit 0
 }
 

--- a/run.sh
+++ b/run.sh
@@ -24,12 +24,12 @@ displayUsage()
   echo "This script creates and start a local private Besu network using Docker."
   echo "You can select the consensus mechanism to use.\n"
   echo "Usage: ${me} [OPTIONS]"
-  echo "    -p or --explorer-port <NUMBER>          : the port number you want to use for the endpoint
-                                              mapping, otherwise default is a port
-                                              automatically selected by Docker."
-  echo "    -c or --consensus <ibft2|clique|ethash> : the consensus mechanism that you want to run
-                                              on your network, default is ethash"
-  echo "    -e or --elk                             : setup ELK with the network."
+  echo "    -p <NUMBER>              : the port number you want to use for the endpoint
+                                       mapping, otherwise default is a port
+                                       automatically selected by Docker."
+  echo "    -c <ibft2|clique|ethash> : the consensus mechanism that you want to run
+                                       on your network, default is ethash"
+  echo "    -e                       : setup ELK with the network."
   exit 0
 }
 


### PR DESCRIPTION
Split out the Privacy examples to run both ELK and non-ELK versions.
NOTE: required 6Gb of Docker memory on Mac if running Privacy with ELK.